### PR TITLE
Update lancer speed attribute

### DIFF
--- a/src/systems.js
+++ b/src/systems.js
@@ -9,7 +9,7 @@ export function getDefaultSpeedAttribute() {
 		case "dnd5e":
 			return "actor.system.attributes.movement.walk";
 		case "lancer":
-			return "actor.system.derived.speed";
+			return "actor.system.speed";
 		case "pf1":
 		case "D35E":
 			return "actor.system.attributes.speed.land.total";


### PR DESCRIPTION
The pending 2.0.0 release has a different path. The current version of lancer is v10 only and the next release will be v11 only, so the change won't affect any current users.